### PR TITLE
Use "magick" instead of "magick convert" in ImageMagick commands

### DIFF
--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -109,7 +109,7 @@ magick_command() {
   # ImageMagick 7 uses `magick` command
   # But older versions use `convert` command
   if command -v magick > /dev/null; then
-    echo "magick convert"
+    echo "magick"
   else
     echo "convert"
   fi


### PR DESCRIPTION
Following message is generated by the script:
```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
```

This commit updates the script to use "magick" directly, which is the recommended way to invoke ImageMagick commands in version 7 and later.
