### PR TITLE
Migrate coverage reporting to octocov

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -1,0 +1,38 @@
+name: octocov
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  octocov:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pollenjp/setup-shfmt@v1
+
+      - name: Install ImageMagick for generate-web-icons
+        run: sudo apt-get install -y imagemagick
+
+      - name: check format with shfmt
+        run: ./tests/shfmt.sh
+
+      - name: lint with shellcheck
+        run: ./tests/shellcheck.sh
+
+      - name: Test
+        run: ./tests/all.sh
+
+      - name: Report coverage with octocov
+        uses: k1LoW/octocov-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config: .octocov.yml

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,17 @@
+# https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
+codeToTestRatio:
+  code:
+    - "bin/**/*.sh"
+  test:
+    - "tests/**/*.sh"
+testExecutionTime:
+  if: true
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+comment:
+  if: is_pull_request
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # shellscript-playground
 
+![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/shellscript-playground/coverage.svg)
+
 ## ja: 概要
 
 このリポジトリは、シェルスクリプトの練習・実験用のリポジトリです。


### PR DESCRIPTION
Add octocov configuration and workflow, and update README coverage badge.