### PR TITLE
Harden test workflow action refs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,17 @@
 name: Test
 on:
   - pull_request
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: pollenjp/setup-shfmt@v1
+      - uses: pollenjp/setup-shfmt@2d2d74023ad2fb047734b97658e911e49f4dfc73
 
       - name: Install ImageMagick for generate-web-icons
         run: sudo apt-get install -y imagemagick


### PR DESCRIPTION
## Summary
- Declare the test workflow token permissions as read-only contents access.
- Pin the checkout and shfmt setup actions to their currently resolved commit SHAs.

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "yaml ok"'
- actionlint .github/workflows/tests.yml
- ./tests/shfmt.sh
- ./tests/shellcheck.sh
- ./tests/all.sh
