### PR TITLE
Fix CWD side effect and stale usage comment in generate-web-icons

### DIFF
--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Generate various web icons by given image file
-# Usage: ./icons.sh <image_file>.<ext>
+# Usage: ./generate-web-icons <image_file>.<ext>
 # Output: <image_file>.tar.gz
 # Dependencies: ImageMagick 6 (`convert`) or ImageMagick 7 (`magick`)
 # Note: The input image file should be square.
@@ -117,11 +117,9 @@ generate_tarball_name() {
   local archive_path="${workdir}/${name}/"
   cp -R "$target_path/"* "$archive_path"
   find "$archive_path" -exec touch -t 197001010000 {} \;
-  cd "$workdir"
   tar -C "$workdir" -cf - "$name" | gzip -n
   rm -rf "$workdir"
   trap - EXIT
-  cd - >/dev/null
 }
 
 magick_command() {


### PR DESCRIPTION
## Summary

`generate_tarball_name` in `bin/generate-web-icons` called `cd "$workdir"` before archiving, which had two problems:

1. **CWD side effect**: the function changed the calling shell process's working directory. Any code relying on CWD after the call would silently run in the wrong location.
2. **Deleted-directory CWD**: `rm -rf "$workdir"` was called while still in `$workdir`, leaving the process momentarily in a deleted directory. The subsequent `cd -` attempted to restore CWD from a directory that no longer existed — behavior that is implementation-defined and can error on some platforms.

The `tar` invocation already used `tar -C "$workdir"`, which handles the directory context without requiring an explicit `cd`. The two `cd` lines were therefore unnecessary and have been removed.

Also fixed a stale usage comment that referenced `./icons.sh` instead of the actual filename `./generate-web-icons`.

## Changes

- `bin/generate-web-icons`: remove `cd "$workdir"` and `cd - >/dev/null` from `generate_tarball_name`
- `bin/generate-web-icons`: fix usage comment filename

## Verification

- `./tests/shfmt.sh` — pass
- `./tests/shellcheck.sh` — pass
- `./tests/all.sh` — pass (both `test-env-run.sh` and `test-generate-web-icons.sh`)
