### PR TITLE
Declare all function-local variables as local in generate-web-icons

### DIFF
--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -48,7 +48,9 @@
 set -euo pipefail
 
 main() {
-  target_file="$1"
+  local target_file="$1"
+  local target_name
+  local workdir_path
   target_name=$(get_name_without_extension "$target_file")
   workdir_path=$(generate_icons_in_tmpdir "$target_file")
   generate_tarball_name "$target_name" "$workdir_path" >"$target_name.tar.gz"
@@ -57,8 +59,8 @@ main() {
 }
 
 generate_icons_in_path() {
-  target_path="$1"
-  icons_dir="$2"
+  local target_path="$1"
+  local icons_dir="$2"
   resize_and_convert "$target_path" "${icons_dir}/favicon.ico" 16
   resize_and_convert "$target_path" "${icons_dir}/favicon16.ico" 16
   resize_and_convert "$target_path" "${icons_dir}/favicon32.ico" 32
@@ -82,7 +84,8 @@ generate_icons_in_path() {
 }
 
 generate_icons_in_tmpdir() {
-  target_file="$1"
+  local target_file="$1"
+  local workdir
   workdir=$(mktemp -d)
   generate_icons_in_path "$target_file" "$workdir"
 }
@@ -91,11 +94,12 @@ generate_tarball_name() {
   # BSD tar has -s option, but GNU tar does not
   # GNU tar has --transform option, but BSD tar does not
   # So, we need to use this workaround
-  name="$1"
-  target_path="$2"
+  local name="$1"
+  local target_path="$2"
+  local workdir
   workdir=$(mktemp -d)
   mkdir -p "$workdir/$name"
-  archive_path="${workdir}/${name}/"
+  local archive_path="${workdir}/${name}/"
   cp -pR "$target_path/"* "$archive_path"
   cd "$workdir"
   tar -C "$workdir" -czf - "$name"
@@ -114,13 +118,14 @@ magick_command() {
 }
 
 resize_and_convert() {
-  target_file="$1"
-  convert_to="$2"
-  size="$3"
+  local target_file="$1"
+  local convert_to="$2"
+  local size="$3"
   $(magick_command) "$target_file" -resize "${size}x${size}" "$convert_to"
 }
 
 get_name_without_extension() {
+  local name
   name=$(basename "$1")
   echo "${name%.*}"
 }


### PR DESCRIPTION
## Summary

Bash functions do not create a new variable scope by default — variables
assigned inside a function are global unless declared with `local`. In
`bin/generate-web-icons`, two functions (`generate_icons_in_tmpdir` and
`generate_tarball_name`) both assign to `workdir`, and two functions
(`generate_tarball_name` and `get_name_without_extension`) both assign
to `name`. Without `local`, reassignment in one function silently
overwrites the value held by another if the call order ever changes.

This PR adds explicit `local` declarations to every function-internal
variable across the script. For command substitutions the declaration
and assignment are split (`local var; var=$(cmd)`) so that a non-zero
exit from the substitution is not masked by the `local` built-in under
`set -e`.

## What changed

- `main`: `target_file`, `target_name`, `workdir_path`
- `generate_icons_in_path`: `target_path`, `icons_dir`
- `generate_icons_in_tmpdir`: `target_file`, `workdir`
- `generate_tarball_name`: `name`, `target_path`, `workdir`, `archive_path`
- `resize_and_convert`: `target_file`, `convert_to`, `size`
- `get_name_without_extension`: `name`

## Testing

- `./tests/shellcheck.sh` — passes (no new warnings)
- `./tests/shfmt.sh` — passes (no formatting changes required)
- `./tests/all.sh` — passes