### PR TITLE
Add argument count and file existence checks to generate-web-icons

### DIFF
--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -48,9 +48,18 @@
 set -euo pipefail
 
 main() {
-  local target_file="$1"
+  local target_file
   local target_name
   local workdir_path
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: $(basename "$0") <image_file>" >&2
+    exit 1
+  fi
+  target_file="$1"
+  if [[ ! -f "$target_file" ]]; then
+    echo "Error: file not found: $target_file" >&2
+    exit 1
+  fi
   target_name=$(get_name_without_extension "$target_file")
   workdir_path=$(generate_icons_in_tmpdir "$target_file")
   generate_tarball_name "$target_name" "$workdir_path" >"$target_name.tar.gz"


### PR DESCRIPTION
## Summary

`bin/generate-web-icons` uses `$1` directly in `main()` without first
checking that an argument was provided. With `set -euo pipefail` in
effect the `-u` flag causes bash to abort immediately with an internal
"unbound variable" error rather than a clear usage message when the
script is called with no arguments.

This PR adds two guards at the top of `main()`:

1. **Argument count check** — exits with a usage message if `$#` is not
   exactly 1.
2. **File existence check** — exits with a clear error if the supplied
   path does not refer to a regular file, rather than letting imagemagick
   produce its own (less user-friendly) error.

## What changed

`main()` in `bin/generate-web-icons`:
- Added `if [[ $# -ne 1 ]]; then echo "Usage: ..." >&2; exit 1; fi`
  before dereferencing `$1`.
- Added `if [[ ! -f "$target_file" ]]; then echo "Error: ..." >&2; exit
  1; fi` after assigning the path.

## Testing

- `./tests/shellcheck.sh` — passes
- `./tests/shfmt.sh` — passes
- `./tests/all.sh` — passes (happy-path coverage unchanged)