### PR TITLE
Make env-run's .env-absent and set -a behaviors explicit

### DIFF
--- a/bin/env-run
+++ b/bin/env-run
@@ -5,11 +5,16 @@
 
 set -euo pipefail
 
-# Load environment variables from .env file if it exists
+# Load environment variables from .env in the current working directory, if present.
+# set -a causes every variable assigned while sourcing .env — including PATH — to be
+# automatically exported to the child process.
+# If .env is absent a warning is printed to stderr and the command runs unchanged.
 # shellcheck disable=SC1091
 if [[ -f .env ]]; then
   set -a
   source .env
   set +a
+else
+  echo "env-run: .env not found in $(pwd); running without loading environment file" >&2
 fi
 exec "$@"


### PR DESCRIPTION
## Summary

`bin/env-run` silently continues with the inherited environment when
`.env` is not present in the current working directory. Because the
script has no observable difference between "loaded .env" and "skipped
.env", a caller that depends on variables from `.env` may execute with
a missing configuration and not notice until a runtime error surfaces.

Additionally, `set -a` causes every variable assigned during `source
.env` — including `PATH` — to be automatically exported to the child
process. This scope is wider than the prior comment implied.

## What changed

- **`else` branch**: emits a one-line warning to stderr when `.env` is
  absent, naming the current working directory. Stdout of the executed
  command is unaffected.
- **Leading comment**: updated to state that `set -a` exports all
  sourced variables (including `PATH`) and that `.env`-absent cases
  emit a stderr warning.

## Testing

- `./tests/shellcheck.sh` — passes
- `./tests/shfmt.sh` — passes
- `./tests/all.sh` — passes (the env-run test creates `.env` before
  calling the script, so the warning path is not triggered)

## Trade-offs

The warning is unconditional — scripts that intentionally run without
`.env` will now see a message on stderr. Callers that want silence can
redirect `2>/dev/null`. A `--quiet` flag would suppress this, but is
out of scope for this change.