### PR TITLE
Fix tmpdir leak on failure in generate-web-icons

### DIFF
--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -84,7 +84,9 @@ generate_icons_in_path() {
 generate_icons_in_tmpdir() {
   target_file="$1"
   workdir=$(mktemp -d)
+  trap 'rm -rf "$workdir"' EXIT
   generate_icons_in_path "$target_file" "$workdir"
+  trap - EXIT
 }
 
 generate_tarball_name() {
@@ -94,12 +96,15 @@ generate_tarball_name() {
   name="$1"
   target_path="$2"
   workdir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf -- $(printf '%q' "$workdir") $(printf '%q' "$target_path")" EXIT
   mkdir -p "$workdir/$name"
   archive_path="${workdir}/${name}/"
   cp -pR "$target_path/"* "$archive_path"
   cd "$workdir"
   tar -C "$workdir" -czf - "$name"
   rm -rf "$workdir"
+  trap - EXIT
   cd - >/dev/null
 }
 


### PR DESCRIPTION
## Why

`set -euo pipefail` causes immediate exit on failure, but neither `generate_icons_in_tmpdir` nor `generate_tarball_name` had `trap ... EXIT` handlers, so their `mktemp -d` directories leaked under `/tmp` when ImageMagick or other internal commands failed.

## What Changed

1. `generate_icons_in_tmpdir` now sets `trap 'rm -rf "$workdir"' EXIT` in the subshell (via command substitution), with `trap - EXIT` on the success path so the caller retains the directory.
2. `generate_tarball_name` now captures both `$workdir` and `$target_path` at trap-setup time so both tmpdirs are cleaned up on failure; `trap - EXIT` is cleared on success since the caller handles the cleanup.

## Verification

All tests pass.

## Trade-offs

This is a surface fix; structural alternatives (global cleanup array) would be more robust for future additions.