### PR TITLE
Show usage for missing CLI arguments

### DIFF
--- a/bin/env-run
+++ b/bin/env-run
@@ -5,6 +5,22 @@
 
 set -euo pipefail
 
+usage() {
+  echo "Usage: env-run <command> [args...]"
+}
+
+if [ "$#" -eq 0 ]; then
+  usage >&2
+  exit 64
+fi
+
+case "$1" in
+-h | --help)
+  usage
+  exit 0
+  ;;
+esac
+
 # Load environment variables from .env in the current working directory, if present.
 # Parses KEY=VALUE lines only; arbitrary shell code is not executed.
 # If .env is absent a warning is printed to stderr and the command runs unchanged.

--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -56,16 +56,20 @@ main() {
     usage >&2
     exit 64
   fi
+  if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+  if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 64
+  fi
   case "$1" in
   -h | --help)
     usage
     exit 0
     ;;
   esac
-  if [[ $# -ne 1 ]]; then
-    usage >&2
-    exit 64
-  fi
   local target_file="$1"
   local target_name
   local workdir_path

--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -47,16 +47,29 @@
 
 set -euo pipefail
 
+usage() {
+  echo "Usage: generate-web-icons <image_file>"
+}
+
 main() {
-  local target_file
+  if [[ $# -eq 0 ]]; then
+    usage >&2
+    exit 64
+  fi
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  esac
+  if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 64
+  fi
+  local target_file="$1"
   local target_name
   local workdir_path
   local tmp_output
-  if [[ $# -ne 1 ]]; then
-    echo "Usage: $(basename "$0") <image_file>" >&2
-    exit 1
-  fi
-  target_file="$1"
   if [[ ! -f "$target_file" ]]; then
     echo "Error: file not found: $target_file" >&2
     exit 1

--- a/tests/test-env-run.sh
+++ b/tests/test-env-run.sh
@@ -16,6 +16,31 @@ if [ "$result" != "bar" ]; then
   echo "Error: FOO must be bar"
   exit 1
 fi
+
+result=$(env-run 2>&1)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "Error: env-run must fail without a command"
+  exit 1
+fi
+if [[ "$result" != *"Usage: env-run <command> [args...]"* ]]; then
+  echo "Error: env-run must show usage without a command"
+  echo "$result"
+  exit 1
+fi
+
+result=$(env-run --help 2>&1)
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "Error: env-run --help must succeed"
+  echo "$result"
+  exit 1
+fi
+if [[ "$result" != *"Usage: env-run <command> [args...]"* ]]; then
+  echo "Error: env-run --help must show usage"
+  echo "$result"
+  exit 1
+fi
 set -e
 
 source "$PROJECT_ROOT/tests/teardown.sh"

--- a/tests/test-generate-web-icons.sh
+++ b/tests/test-generate-web-icons.sh
@@ -18,6 +18,32 @@ assert_tar_contains_target_file() {
 
 set +e
 export PATH="$PROJECT_ROOT/bin:$PRESERVE_PATH"
+
+result=$(generate-web-icons 2>&1)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "Failed to reject missing input image"
+  exit 1
+fi
+if [[ "$result" != *"Usage: generate-web-icons <image_file>"* ]]; then
+  echo "Failed to show usage for missing input image"
+  echo "$result"
+  exit 1
+fi
+
+result=$(generate-web-icons --help 2>&1)
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "Failed to show help"
+  echo "$result"
+  exit 1
+fi
+if [[ "$result" != *"Usage: generate-web-icons <image_file>"* ]]; then
+  echo "Failed to show usage for help"
+  echo "$result"
+  exit 1
+fi
+
 result=$(generate-web-icons "$icon_file")
 status=$?
 tobe_tarball="./example-icon.tar.gz"


### PR DESCRIPTION
## Summary
- add usage output for env-run and generate-web-icons
- return a non-zero usage exit when required arguments are missing
- cover missing-argument and --help behavior in shell tests

## Tests
- ./tests/shfmt.sh
- ./tests/shellcheck.sh
- ./tests/all.sh
- find bin tests -type f -exec bash -n {} +
