### PR TITLE
Remove partial output file when tarball generation fails

### DIFF
--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -51,7 +51,9 @@ main() {
   target_file="$1"
   target_name=$(get_name_without_extension "$target_file")
   workdir_path=$(generate_icons_in_tmpdir "$target_file")
+  trap 'rm -f "${target_name}.tar.gz"' ERR
   generate_tarball_name "$target_name" "$workdir_path" >"$target_name.tar.gz"
+  trap - ERR
   # clean up
   rm -rf "$workdir_path"
 }


### PR DESCRIPTION
## Summary

`bin/generate-web-icons` creates the output `.tar.gz` file via shell
redirection before executing `generate_tarball_name`. If the function
fails, the file already exists on disk but is empty or incomplete —
a misleading artifact that looks like a valid tarball.

Add an ERR trap in `main()` to remove the partial file when any command
fails after the redirect is opened. Reset the trap after a successful
write so normal cleanup proceeds unaffected.

## Changes

- `bin/generate-web-icons`: add `trap 'rm -f "${target_name}.tar.gz"' ERR`
  before the redirect and `trap - ERR` after

## Verification

- `./tests/shfmt.sh` — no formatting issues
- `./tests/shellcheck.sh` — no lint warnings
- `./tests/all.sh` — all tests pass
