### PR TITLE
Write tarball to temp file then rename atomically

### DIFF
--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -51,7 +51,9 @@ main() {
   target_file="$1"
   target_name=$(get_name_without_extension "$target_file")
   workdir_path=$(generate_icons_in_tmpdir "$target_file")
-  generate_tarball_name "$target_name" "$workdir_path" >"$target_name.tar.gz"
+  tmp_output=$(mktemp "${target_name}.tar.gz.XXXXXX")
+  generate_tarball_name "$target_name" "$workdir_path" >"$tmp_output"
+  mv "$tmp_output" "${target_name}.tar.gz"
   # clean up
   rm -rf "$workdir_path"
 }


### PR DESCRIPTION
## Summary

`bin/generate-web-icons` wrote the output tarball using a shell redirect
(`>"$target_name.tar.gz"`), which creates the destination file before the
command runs. This means the file exists as empty or incomplete for the
several seconds ImageMagick needs to convert 19 icons and pack them with tar.
Concurrent readers (e.g. CI matrix jobs, parallel shell sessions) can observe
the file, pass an existence check (`-f`), and then fail trying to decompress
it.

This change applies the write-then-rename pattern: write to a `mktemp` temp
file and atomically rename it to the final path with `mv` only after generation
completes. On the same filesystem, `mv` resolves to a `rename(2)` syscall,
which is atomic — the final path either points to the complete tarball or does
not exist.

## Change

- `bin/generate-web-icons`: redirect to `mktemp` temp file, then `mv` to final path

## Verification

All existing tests pass (`tests/test-generate-web-icons.sh`), including checks
that the tarball contains every expected icon file. shellcheck and shfmt report
no issues.
