### PR TITLE
Document ImageMagick compatibility and test magick dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ However, I will avoid making too much effort for compatibility and supplement it
 
 If possible, I will write tests.
 
+## ja: 依存関係
+
+`generate-web-icons` は ImageMagick 7 の `magick` と ImageMagick 6 の `convert` をサポートします。
+`magick` が存在する場合は優先して使い、 Ubuntu の `imagemagick` パッケージとこのリポジトリの CI ベースラインが ImageMagick 6 を提供している間は `convert` のフォールバックを維持します。
+
+## en: Dependencies
+
+`generate-web-icons` supports ImageMagick 7 through `magick` and ImageMagick 6 through `convert`.
+It prefers `magick` when available, and keeps the `convert` fallback while Ubuntu's `imagemagick` package and this repository's CI baseline provide ImageMagick 6.
+
 ## Installation
 
 ```bash

--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -3,7 +3,7 @@
 # Generate various web icons by given image file
 # Usage: ./icons.sh <image_file>.<ext>
 # Output: <image_file>.tar.gz
-# Dependencies: ImageMagick
+# Dependencies: ImageMagick 6 (`convert`) or ImageMagick 7 (`magick`)
 # Note: The input image file should be square.
 # The output tarball contains the following files:
 # - favicon16.ico
@@ -113,8 +113,10 @@ generate_tarball_name() {
 }
 
 magick_command() {
-  # ImageMagick 7 uses `magick` command
-  # But older versions use `convert` command
+  # Support ImageMagick 7 with `magick` and ImageMagick 6 with `convert`.
+  # Keep the `convert` fallback while Ubuntu's packaged imagemagick and CI
+  # baseline provide ImageMagick 6. Remove it only after supported runtime
+  # images provide `magick`.
   if command -v magick >/dev/null; then
     echo "magick"
   else

--- a/tests/test-generate-web-icons.sh
+++ b/tests/test-generate-web-icons.sh
@@ -56,4 +56,37 @@ assert_tar_contains_target_file "$tobe_tarball" "example-icon/favicon192.png"
 
 set -e
 
+rm -f "$tobe_tarball"
+
+fake_bin="$WORK_DIR/fake-bin"
+magick_calls="$WORK_DIR/magick-calls.log"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/magick" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$MAGICK_CALL_LOG"
+target_file="${@: -1}"
+mkdir -p "$(dirname "$target_file")"
+printf 'fake icon\n' >"$target_file"
+BASH
+chmod +x "$fake_bin/magick"
+
+MAGICK_CALL_LOG="$magick_calls" PATH="$fake_bin:$PROJECT_ROOT/bin:/bin:/usr/bin" generate-web-icons "$icon_file"
+
+if [ ! -f "$tobe_tarball" ]; then
+  echo "Failed to generate web icons with magick command"
+  echo "Tarball file not found: $tobe_tarball"
+  exit 1
+fi
+
+if [ ! -s "$magick_calls" ]; then
+  echo "Failed to use magick command"
+  exit 1
+fi
+
+assert_tar_contains_target_file "$tobe_tarball" "example-icon/favicon.ico"
+assert_tar_contains_target_file "$tobe_tarball" "example-icon/favicon192.png"
+
 source "$PROJECT_ROOT/tests/teardown.sh"


### PR DESCRIPTION
Summary:
- Document ImageMagick 6 and 7 command compatibility for generate-web-icons.
- Clarify when the convert fallback should be retained or removed.
- Add a fake magick test path so the ImageMagick 7 dispatch branch is covered in CI.

Tests:
- ./tests/shfmt.sh
- ./tests/shellcheck.sh
- ./tests/all.sh
- git diff --check
- bash -n bin/generate-web-icons tests/test-generate-web-icons.sh
