### PR TITLE
Run apt-get update before installing ImageMagick

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: pollenjp/setup-shfmt@2d2d74023ad2fb047734b97658e911e49f4dfc73
 
       - name: Install ImageMagick for generate-web-icons
-        run: sudo apt-get install -y imagemagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
 
       - name: check format with shfmt
         run: ./tests/shfmt.sh


### PR DESCRIPTION
Summary:
- Refresh the apt package index before installing ImageMagick in the test workflow.
- Keep the ImageMagick install step scoped to the existing generate-web-icons CI dependency.

Tests:
- ./tests/shfmt.sh
- ./tests/shellcheck.sh
- ./tests/all.sh
- git diff --check
- actionlint
- implement-validator: overall pass
