### PR TITLE
ci: log installed ImageMagick version after install step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,14 @@ jobs:
       - name: Install ImageMagick for generate-web-icons
         run: sudo apt-get install -y imagemagick
 
+      - name: Log ImageMagick version
+        run: |
+          if command -v magick >/dev/null 2>&1; then
+            magick -version | head -1
+          else
+            convert -version | head -1
+          fi
+
       - name: check format with shfmt
         run: ./tests/shfmt.sh
 


### PR DESCRIPTION
## Summary

The CI workflow installs ImageMagick with `apt-get install -y imagemagick` but does
not record which version was installed. When `ubuntu-latest` upgrades to a new OS
release, the installed ImageMagick version silently changes, making it difficult to
detect regressions caused by version differences.

This PR adds a **Log ImageMagick version** step immediately after the install step.
The step mirrors the `magick_command()` dispatch logic from `bin/generate-web-icons`
(prefer `magick` for ImageMagick 7, fall back to `convert` for ImageMagick 6) and
emits the version string to the CI log.

No behavior change to the scripts — the install step and test suite are unchanged.

## Changes

- `.github/workflows/tests.yml`: add "Log ImageMagick version" step after install

## Test plan

- [x] `./tests/shfmt.sh` — format check passes
- [x] `./tests/shellcheck.sh` — no shellcheck findings on the modified file
- [x] `actionlint .github/workflows/tests.yml` — no workflow errors

## Trade-offs

The step logs the version but does not fail if it is below a minimum threshold. A
minimum-version enforcement step would be more strict but requires maintaining a
hardcoded version string that breaks when the Ubuntu runner OS changes. Logging only
provides observability without fragility.
