### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Add the following to your `.bashrc` or `.zshrc`:
 export PATH="$PATH:/path/to/shellscript-playground/bin"
 ```
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and then run:
+
+```bash
+lefthook install
+```
+
+This sets up the following Git hooks:
+
+- **pre-commit**: runs `./tests/shfmt.sh` (format check) and `./tests/shellcheck.sh` (lint)
+- **pre-push**: runs `./tests/shfmt.sh`, `./tests/shellcheck.sh`, and `./tests/all.sh` (full test suite)
+
+CI runs the full suite (`shfmt`, `shellcheck`, and `all.sh`) on every pull request.
+
 ## LICENSE
 
 MIT License

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  commands:
+    shfmt:
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; ./tests/shfmt.sh
+    shellcheck:
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; ./tests/shellcheck.sh
+
+pre-push:
+  commands:
+    shfmt:
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; ./tests/shfmt.sh
+    shellcheck:
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; ./tests/shellcheck.sh
+    all:
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; ./tests/all.sh


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to run CI checks locally via Git hooks
- Add a `## Development` section to `README.md` explaining how to install and use the hooks

## What the hooks do

- **pre-commit**: runs `./tests/shfmt.sh` (format check) and `./tests/shellcheck.sh` (lint)
- **pre-push**: runs `./tests/shfmt.sh`, `./tests/shellcheck.sh`, and `./tests/all.sh` (full test suite)

This mirrors what CI runs on every pull request, so developers catch issues before pushing.

## Files changed

- `lefthook.yml` — new file defining pre-commit and pre-push hooks
- `README.md` — new `## Development` section with setup instructions

## Test plan

- [ ] Run `lefthook install` in a fresh clone
- [ ] Verify `git commit` triggers `shfmt` and `shellcheck`
- [ ] Verify `git push` triggers `shfmt`, `shellcheck`, and `all.sh`
- [ ] Confirm CI (`.github/workflows/tests.yml`) is unchanged
