### PR TITLE
Reject oversized env-run input before exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ If possible, I will write tests.
 `generate-web-icons` supports ImageMagick 7 through `magick` and ImageMagick 6 through `convert`.
 It prefers `magick` when available, and keeps the `convert` fallback while Ubuntu's `imagemagick` package and this repository's CI baseline provide ImageMagick 6.
 
+## env-run input limits
+
+`env-run` reads `.env` from the current working directory and rejects oversized input before exporting it:
+
+- Maximum `.env` size: 65,536 bytes (configurable via `ENV_RUN_MAX_ENV_BYTES`)
+- Maximum value size per variable: 4,096 bytes (configurable via `ENV_RUN_MAX_VALUE_BYTES`)
+
+If either bound is exceeded, `env-run` exits with an error instead of invoking the target command.
+
 ## Installation
 
 ```bash

--- a/bin/env-run
+++ b/bin/env-run
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+readonly ENV_RUN_MAX_ENV_BYTES="${ENV_RUN_MAX_ENV_BYTES:-65536}"
+readonly ENV_RUN_MAX_VALUE_BYTES="${ENV_RUN_MAX_VALUE_BYTES:-4096}"
+
 usage() {
   echo "Usage: env-run <command> [args...]"
 }
@@ -25,6 +28,12 @@ esac
 # Parses KEY=VALUE lines only; arbitrary shell code is not executed.
 # If .env is absent a warning is printed to stderr and the command runs unchanged.
 if [[ -f .env ]]; then
+  env_bytes=$(wc -c <.env | tr -d '[:space:]')
+  if ((env_bytes > ENV_RUN_MAX_ENV_BYTES)); then
+    echo "env-run: .env is too large (${env_bytes} bytes > ${ENV_RUN_MAX_ENV_BYTES} bytes)" >&2
+    exit 65
+  fi
+
   while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^[[:space:]]*# ]] && continue
     [[ "$line" =~ ^[[:space:]]*$ ]] && continue
@@ -32,6 +41,10 @@ if [[ -f .env ]]; then
     key="${line%%=*}"
     value="${line#*=}"
     if [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      if ((${#value} > ENV_RUN_MAX_VALUE_BYTES)); then
+        echo "env-run: value for ${key} is too large (${#value} bytes > ${ENV_RUN_MAX_VALUE_BYTES} bytes)" >&2
+        exit 65
+      fi
       export "${key}=${value}"
     fi
   done <.env

--- a/tests/test-env-run.sh
+++ b/tests/test-env-run.sh
@@ -41,6 +41,38 @@ if [[ "$result" != *"Usage: env-run <command> [args...]"* ]]; then
   echo "$result"
   exit 1
 fi
+
+python3 - <<'PY' >.env
+print("BIG=" + "x" * 4097)
+PY
+# shellcheck disable=SC2016
+result=$(env-run sh -c 'echo "$BIG"' 2>&1)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "Error: env-run must reject oversized values"
+  exit 1
+fi
+if [[ "$result" != *"env-run: value for BIG is too large"* ]]; then
+  echo "Error: env-run must explain oversized value rejection"
+  echo "$result"
+  exit 1
+fi
+
+python3 - <<'PY' >.env
+for i in range(700):
+    print(f"K{i}=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+PY
+result=$(env-run sh -c 'echo ok' 2>&1)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "Error: env-run must reject oversized .env files"
+  exit 1
+fi
+if [[ "$result" != *"env-run: .env is too large"* ]]; then
+  echo "Error: env-run must explain oversized .env rejection"
+  echo "$result"
+  exit 1
+fi
 set -e
 
 source "$PROJECT_ROOT/tests/teardown.sh"


### PR DESCRIPTION
## Summary

Reject oversized `.env` input in `env-run` before starting the target command.

## What Changed

- reject `.env` files larger than 65,536 bytes before exporting variables
- reject individual variable values larger than 4,096 bytes
- cover oversized value and oversized file paths in `tests/test-env-run.sh`
- document the supported `env-run` bounds in `README.md`

## Why

`env-run` previously exported every parsed `KEY=VALUE` entry without bounding the total environment size or individual values. That let a large `.env` payload reach `exec`, where failures would surface later and with less clear ownership.

## Verification

- `./tests/shfmt.sh`
- `./tests/shellcheck.sh`
- `./tests/all.sh`
