### PR TITLE
Reject oversized generate-web-icons inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ If possible, I will write tests.
 `generate-web-icons` supports ImageMagick 7 through `magick` and ImageMagick 6 through `convert`.
 It prefers `magick` when available, and keeps the `convert` fallback while Ubuntu's `imagemagick` package and this repository's CI baseline provide ImageMagick 6.
 
+## generate-web-icons input limits
+
+`generate-web-icons` validates input images before conversion:
+
+- Maximum file size: 50MB (configurable via `GENERATE_WEB_ICONS_MAX_INPUT_BYTES`)
+- Maximum width or height: 4,096 pixels (configurable via `GENERATE_WEB_ICONS_MAX_INPUT_DIMENSION`)
+- Maximum pixel count: 16,777,216 pixels (configurable via `GENERATE_WEB_ICONS_MAX_INPUT_PIXELS`)
+
+If an input image exceeds these bounds, the script exits with a clear error before invoking conversion.
+
 ## Installation
 
 ```bash

--- a/bin/generate-web-icons
+++ b/bin/generate-web-icons
@@ -47,6 +47,10 @@
 
 set -euo pipefail
 
+DEFAULT_MAX_INPUT_BYTES=52428800
+DEFAULT_MAX_INPUT_DIMENSION=4096
+DEFAULT_MAX_INPUT_PIXELS=16777216
+
 usage() {
   echo "Usage: generate-web-icons <image_file>"
 }
@@ -78,6 +82,10 @@ main() {
     echo "Error: file not found: $target_file" >&2
     exit 1
   fi
+  validate_input_image_limits "$target_file" \
+    "${GENERATE_WEB_ICONS_MAX_INPUT_BYTES:-$DEFAULT_MAX_INPUT_BYTES}" \
+    "${GENERATE_WEB_ICONS_MAX_INPUT_DIMENSION:-$DEFAULT_MAX_INPUT_DIMENSION}" \
+    "${GENERATE_WEB_ICONS_MAX_INPUT_PIXELS:-$DEFAULT_MAX_INPUT_PIXELS}"
   target_name=$(get_name_without_extension "$target_file")
   workdir_path=$(create_icons_tmpdir "$target_file")
   tmp_output=$(mktemp "${target_name}.tar.gz.XXXXXX")
@@ -171,6 +179,67 @@ get_name_without_extension() {
     fi
   fi
   echo "${name%.*}"
+}
+
+validate_input_image_limits() {
+  local target_file="$1"
+  local max_bytes="$2"
+  local max_dimension="$3"
+  local max_pixels="$4"
+  local file_size
+  local dimensions
+  local width
+  local height
+  local pixel_count
+
+  file_size=$(wc -c <"$target_file" | tr -d '[:space:]')
+  if ((file_size > max_bytes)); then
+    echo "Error: input image is too large: ${file_size} bytes. Max allowed is ${max_bytes} bytes." >&2
+    exit 1
+  fi
+
+  if ! dimensions=$(identify_image_dimensions "$target_file"); then
+    echo "Error: failed to read image dimensions for ${target_file}" >&2
+    exit 1
+  fi
+
+  read -r width height <<<"$dimensions"
+  if ! [[ "$width" =~ ^[0-9]+$ && "$height" =~ ^[0-9]+$ ]]; then
+    echo "Error: invalid image dimension output: ${dimensions}" >&2
+    exit 1
+  fi
+
+  if ((width > max_dimension || height > max_dimension)); then
+    echo "Error: input image dimensions are too large: ${width}x${height}. Max allowed is ${max_dimension}x${max_dimension}." >&2
+    exit 1
+  fi
+
+  pixel_count=$((width * height))
+  if ((pixel_count > max_pixels)); then
+    echo "Error: input image pixel count too large: ${pixel_count} (width=${width}, height=${height}). Max allowed is ${max_pixels} pixels." >&2
+    exit 1
+  fi
+}
+
+identify_image_dimensions() {
+  local target_file="$1"
+
+  if command -v identify >/dev/null 2>&1; then
+    identify -format "%w %h" "$target_file"
+    return
+  fi
+
+  if command -v magick >/dev/null 2>&1; then
+    magick identify -format "%w %h" "$target_file"
+    return
+  fi
+
+  if command -v convert >/dev/null 2>&1; then
+    convert "$target_file" -format "%w %h" info:
+    return
+  fi
+
+  return 1
 }
 
 main "$@"

--- a/tests/test-generate-web-icons.sh
+++ b/tests/test-generate-web-icons.sh
@@ -80,6 +80,45 @@ assert_tar_contains_target_file "$tobe_tarball" "example-icon/favicon48.png"
 assert_tar_contains_target_file "$tobe_tarball" "example-icon/favicon96.png"
 assert_tar_contains_target_file "$tobe_tarball" "example-icon/favicon192.png"
 
+result=$(GENERATE_WEB_ICONS_MAX_INPUT_BYTES=1 generate-web-icons "$icon_file" 2>&1)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "Failed to reject oversized file by byte limit"
+  echo "$result"
+  exit 1
+fi
+if [[ "$result" != *"input image is too large"* ]]; then
+  echo "Failed to show oversized file limit message"
+  echo "$result"
+  exit 1
+fi
+
+result=$(GENERATE_WEB_ICONS_MAX_INPUT_DIMENSION=16 generate-web-icons "$icon_file" 2>&1)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "Failed to reject oversized image by dimension limit"
+  echo "$result"
+  exit 1
+fi
+if [[ "$result" != *"input image dimensions are too large"* ]]; then
+  echo "Failed to show oversized dimension limit message"
+  echo "$result"
+  exit 1
+fi
+
+result=$(GENERATE_WEB_ICONS_MAX_INPUT_PIXELS=1 generate-web-icons "$icon_file" 2>&1)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "Failed to reject oversized image by pixel limit"
+  echo "$result"
+  exit 1
+fi
+if [[ "$result" != *"input image pixel count too large"* ]]; then
+  echo "Failed to show oversized pixel limit message"
+  echo "$result"
+  exit 1
+fi
+
 set -e
 
 rm -f "$tobe_tarball"
@@ -93,6 +132,10 @@ cat >"$fake_bin/magick" <<'BASH'
 set -euo pipefail
 
 printf '%s\n' "$*" >>"$MAGICK_CALL_LOG"
+if [ "$1" = "identify" ]; then
+  printf '16 16\n'
+  exit 0
+fi
 target_file="${@: -1}"
 mkdir -p "$(dirname "$target_file")"
 printf 'fake icon\n' >"$target_file"
@@ -109,6 +152,11 @@ fi
 
 if [ ! -s "$magick_calls" ]; then
   echo "Failed to use magick command"
+  exit 1
+fi
+if ! grep -q '^identify ' "$magick_calls"; then
+  echo "Failed to use magick identify fallback"
+  cat "$magick_calls"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- reject oversized `generate-web-icons` inputs before the resize loop starts
- document the supported byte, dimension, and pixel limits in `README.md`
- cover byte-limit, dimension-limit, pixel-limit, and `magick identify` fallback paths in tests

## Why
`generate-web-icons` previously passed any existing image straight into 19 ImageMagick conversions. Large or expensive-to-expand images could therefore consume CPU, memory, and temporary disk repeatedly before the script reported a failure.

## Verification
- `./tests/shfmt.sh`
- `./tests/shellcheck.sh`
- `./tests/all.sh`
