### PR TITLE
Make standalone test entrypoints self-initialize

### DIFF
--- a/tests/test-env-run.sh
+++ b/tests/test-env-run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source "$PROJECT_ROOT/tests/setup.sh"
+TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=tests/setup.sh
+source "$TESTS_DIR/setup.sh"
 echo "FOO=bar" >.env
 
 set +e
@@ -75,4 +77,5 @@ if [[ "$result" != *"env-run: .env is too large"* ]]; then
 fi
 set -e
 
-source "$PROJECT_ROOT/tests/teardown.sh"
+# shellcheck source=tests/teardown.sh
+source "$TESTS_DIR/teardown.sh"

--- a/tests/test-generate-web-icons.sh
+++ b/tests/test-generate-web-icons.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PRESERVE_PATH="$PATH"
-source "$PROJECT_ROOT/tests/setup.sh"
+# shellcheck source=tests/setup.sh
+source "$TESTS_DIR/setup.sh"
 
 # Get example .png icon file
 icon_file="$PROJECT_ROOT/assets/icons/example-icon.png"
@@ -164,4 +166,5 @@ assert_tar_contains_target_file "$dotfile_tarball" ".hidden-icon/favicon.ico"
 assert_tar_contains_target_file "$dotfile_tarball" ".hidden-icon/favicon192.png"
 rm -f "$dotfile_tarball"
 
-source "$PROJECT_ROOT/tests/teardown.sh"
+# shellcheck source=tests/teardown.sh
+source "$TESTS_DIR/teardown.sh"


### PR DESCRIPTION
## 概要
- `tests/test-env-run.sh` と `tests/test-generate-web-icons.sh` が `PROJECT_ROOT` の事前 export に依存せず、自身の配置場所から `setup.sh` / `teardown.sh` を読み込むようにしました
- 動的な `source` パスに対して `shellcheck` の参照先を明示し、既存の lint 契約を維持しました

## 背景
- `tests/all.sh` 経由では `PROJECT_ROOT` が export される一方、個別実行では `/tests/setup.sh` を探して失敗していました
- 失敗原因が対象コマンドではなく初期化順序の暗黙前提へすり替わっていたため、各テスト入口で自己完結させています

## 検証
- `bash tests/test-env-run.sh`
- `bash tests/test-generate-web-icons.sh`
- `./tests/shfmt.sh`
- `./tests/shellcheck.sh`
- `./tests/all.sh`
